### PR TITLE
Move PromptWorks dotfile repo to ~/.promptworks-dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ lsrc -v
 
 Checkout the repo
 ```
-git clone git@github.com:promptworks/dotfiles.git /usr/local/share/promptworks-dotfiles
+git clone git@github.com:promptworks/dotfiles.git ~/.promptworks-dotfiles
 ```
 
 Tell rcup about the promptworks dotfiles the first time and run rcup:
 ```
-rcup -K -d /usr/local/share/promptworks-dotfiles rcrc
+rcup -K -d ~/.promptworks-dotfiles rcrc
 rcup
 ```
 
@@ -48,7 +48,7 @@ rcup -v
 ## Updating your PromptWorks dotfiles
 
 ```
-cd /usr/local/share/promptworks-dotfiles
+cd ~/.promptworks-dotfiles
 git pull
 rcup -v
 ```

--- a/aliases
+++ b/aliases
@@ -14,7 +14,7 @@ alias e="$EDITOR"
 alias v="$VISUAL"
 
 # rcm
-alias rcupup="cd /usr/local/share/promptworks-dotfiles && git pull && rcup -v"
+alias rcupup="cd ~/.promptworks-dotfiles && git pull && rcup -v"
 
 # git
 alias gci="git pull --rebase && rake && git push"

--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,2 @@
 EXCLUDES="README.md LICENSE Brewfile"
-DOTFILES_DIRS="$HOME/.dotfiles /usr/local/share/promptworks-dotfiles"
+DOTFILES_DIRS="$HOME/.dotfiles $HOME/.promptworks-dotfiles"


### PR DESCRIPTION
Since we expect the custom dotfiles in ~/.dotfiles, it doesn't seem to
make much sense to have the PromptWorks dotfiles in a totally other
location.

Plus, it's much easier to remember where they are when they are in your
home directory.
