### PR TITLE
Remove vi mode from ZSH config

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -43,11 +43,6 @@ setopt extendedglob
 # Allow [ or ] whereever you want
 unsetopt nomatch
 
-# vi mode
-bindkey -v
-bindkey "^F" vi-cmd-mode
-bindkey jj vi-cmd-mode
-
 # handy keybindings
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line


### PR DESCRIPTION
Reasons:
1. It screws up keyboard commands that everyone is used to. Like `<ESC><DELETE>`
2. I don't understand the appeal of vi mode. Things like `ciaw` don't work. Perhaps I am unenlightened.
