### PR TITLE
Add `gtidy` command to tidy up local git branches

### DIFF
--- a/aliases
+++ b/aliases
@@ -19,6 +19,7 @@ alias rcupup="cd ~/.promptworks-dotfiles && git pull && rcup -v"
 # git
 alias gci="git pull --rebase && rake && git push"
 alias ggrep="git grep --break --heading -n"
+alias gtidy="git remote prune origin && git branch --merged master | egrep -v 'master|develop$' | xargs git branch -d"
 
 # Bundler
 alias b="bundle"


### PR DESCRIPTION
This will call `git remote prune origin` to delete references to branches that were deleted upstream, and find all *local* branches that have been merged to master (not named "master" or "develop") and delete them.

This doesn't affect any branches on the remote, just cleans up one's local repo of already-merged branches.