### PR TITLE
Disable underscore autocompletion

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -111,3 +111,6 @@ function title() {
     ;;
   esac
 }
+
+# Don't do weird underscore autocompletion for stuff that doesn't exist
+zstyle ':completion:*:functions' ignored-patterns '_*'


### PR DESCRIPTION
Before, in zsh, you would get the following:

```
$ cd _<tab>
_amavisd               _cvmsroot              _iconservices          _lda                   _postfix               _timezone
_appleevents           _cvs                   _installassistant      _locationd             _postgres              _tokend
_appowner              _cyrus                 _installer             _lp                    _qtss                  _trustevaluationagent
_appserver             _devdocs               _jabber                _mailman               _sandbox               _unknown
_ard                   _devicemgr             _kadmin_admin          _mbsetupuser           _screensaver           _update_sharing
_assetcache            _displaypolicyd        _kadmin_changepw       _mcxalr                _scsd                  _usbmuxd
_astris                _distnote              _krb_anonymous         _mdnsresponder         _securityagent         _uucp
_atsserver             _dovecot               _krb_changepw          _mysql                 _serialnumberd         _warmd
_avbdeviced            _dovenull              _krb_kadmin            _netbios               _softwareupdate        _webauthserver
_calendar              _dpaudio               _krb_kerberos          _netstatistics         _spotlight             _windowserver
_ces                   _eppc                  _krb_krbtgt            _networkd              _sshd                  _www
_clamav                _ftp                   _krbfast               _nsurlsessiond         _svn                   _wwwproxy
_coreaudiod            _gamecontrollerd       _krbtgt                _nsurlstoraged         _taskgated             _xserverdocs
_coremediaiod          _geod                  _launchservicesd       _ondemand              _teamsserver
```

which is annoying when you just want to cd to a directory that starts with an underscore.

This PR disables that behavior.