### PR TITLE
Remove defunct utf8 tmux configuration

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,6 +1,5 @@
 # improve colors
 set -g default-terminal 'screen-256color'
-set -g utf8 on
 
 # act like vim
 setw -g mode-keys vi


### PR DESCRIPTION
When creating a new tmux session, on tmux 2.6 (latest) I was getting this error:

```
/Users/petercaisse/.tmux.conf:3: invalid option: utf8
```

This PR deletes the setting from `tmux.conf` that uses this option.